### PR TITLE
Fixed shell used in startup script

### DIFF
--- a/.docker/start.sh
+++ b/.docker/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 mkdir -p /var/atlassian/application-data/jira/plugins/installed-plugins
 cp /opt/dbconfig.xml /var/atlassian/application-data/jira/dbconfig.xml


### PR DESCRIPTION
Using bash in start.sh script seems not to work with latest version of atlassian/jira-software. docker compose up fails with:

/bin/sh: 1: /opt/start.sh: not found

Changing shebang to /bin/sh fixes it